### PR TITLE
Adjust doc title

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: quarkus-zookeeper-client
-title: Quarkus Zookeeper Client
+title: Zookeeper Client
 version: dev
 nav:
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
This will remove the  `Quarkus ` prefix in the documentation title