### PR TITLE
Fix asciidoc warnings

### DIFF
--- a/docs/modules/ROOT/pages/config/quarkus-zookeeper.adoc
+++ b/docs/modules/ROOT/pages/config/quarkus-zookeeper.adoc
@@ -262,15 +262,4 @@ Environment variable: `+++QUARKUS_ZOOKEEPER_SESSION_CAN_BE_READ_ONLY+++`
 --|boolean 
 |`false`
 
-
-a| [[quarkus-zookeeper_quarkus.zookeeper.health.enabled]]`link:#quarkus-zookeeper_quarkus.zookeeper.health.enabled[quarkus.zookeeper.health.enabled]`
-
-[.description]
---
-Whether to enable health checks.
-
-Environment variable: `+++QUARKUS_ZOOKEEPER_HEALTH_ENABLED+++`
---|boolean 
-|`true`
-
 |===

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,7 +1,7 @@
 = Quarkus - Zookeeper Client
 :extension-status: dev
 
-Stateful client to Apache Zookeeper (https://zookeeper.apache.org/).
+Stateful client to Apache ZooKeeper (https://zookeeper.apache.org/).
 
 ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 


### PR DESCRIPTION
Proof of all warnings gone:
<img width="317" alt="image" src="https://github.com/quarkiverse/quarkus-zookeeper-client/assets/11942401/3fc41e53-ef7c-4e53-9fb2-20ab67d63cc5">

Proof of warnings before this PR:
<img width="1002" alt="image" src="https://github.com/quarkiverse/quarkus-zookeeper-client/assets/11942401/d8f7f87f-cefe-401b-9f6b-050cbef82415">
